### PR TITLE
修复编译错误：修改项目依赖的SuperControls.Style.dll路径为本工程内

### DIFF
--- a/Jvedio-WPF/Jvedio.Style/Jvedio.Style.csproj
+++ b/Jvedio-WPF/Jvedio.Style/Jvedio.Style.csproj
@@ -43,7 +43,7 @@
     </Reference>
     <Reference Include="PresentationFramework.Aero" />
     <Reference Include="SuperControls.Style">
-      <HintPath>..\..\..\..\SuperStudio\SuperControls\SuperControls.Style\bin\Debug\SuperControls.Style.dll</HintPath>
+      <HintPath>..\Jvedio\Reference\SuperControls.Style.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/Jvedio-WPF/Jvedio/Jvedio.csproj
+++ b/Jvedio-WPF/Jvedio/Jvedio.csproj
@@ -181,7 +181,7 @@
       <HintPath>Lib\QueryEngine.dll</HintPath>
     </Reference>
     <Reference Include="SuperControls.Style">
-      <HintPath>..\..\..\..\SuperStudio\SuperControls\SuperControls.Style\bin\Debug\SuperControls.Style.dll</HintPath>
+      <HintPath>Reference\SuperControls.Style.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">


### PR DESCRIPTION
修改SuperControls.Style.dll引用的路径地址